### PR TITLE
fixed:mapIdの設定漏れ修正

### DIFF
--- a/app/javascript/controllers/searchs_controller.js
+++ b/app/javascript/controllers/searchs_controller.js
@@ -12,6 +12,7 @@ export default class extends Controller {
 
   static values = {
     apiKey: String,
+    mapId: String,
     records: Array,
     spot: Object,
   };

--- a/app/javascript/controllers/spots_controller.js
+++ b/app/javascript/controllers/spots_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
 
   static values = {
     apiKey: String,
+    mapId: String,
     records: Array,
   };
 


### PR DESCRIPTION
## 概要
- mapIdを値をstimulusのコントローラーで受け取り忘れていたため、修正した。