### PR TITLE
fixed:モデルの自動ジオコーディング設定削除

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,8 +1,8 @@
 class Spot < ApplicationRecord
-  # geocoderの設定
-  geocoded_by :address
-  reverse_geocoded_by :latitude, :longitude
-  after_validation :geocode
+  # geocoderの設定(入力フォームのデータを保存したい場合は、下記はない方が良いかも)
+  # geocoded_by :address
+  # reverse_geocoded_by :latitude, :longitude
+  # after_validation :geocode
 
   # バリデーション
   validates :address, presence: true


### PR DESCRIPTION
## 概要
- モデルに設定していた「geocoded_by :address」「reverse_geocoded_by :latitude, :longitude」「after_validation :geocode」は、入力フォームからデータを送信した場合、その値からジオコーディング、リバースジオコーディングを行うらしい。バリデーション時にインスタンスにその結果を代入してから登録処理が行われるため、入力フォームから送信された結果と登録された結果にズレがあった。そのため、モデルに設定されていた上記の３つをコメントアウトして削除した。