### PR TITLE
02 fix api

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,8 +1,8 @@
 class Spot < ApplicationRecord
   # geocoderの設定(入力フォームのデータを保存したい場合は、下記はない方が良いかも)
-  # geocoded_by :address
+  geocoded_by :address
   reverse_geocoded_by :latitude, :longitude
-  after_validation :geocode
+  # after_validation :geocode
 
   # バリデーション
   validates :address, presence: true

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,8 +1,8 @@
 class Spot < ApplicationRecord
   # geocoderの設定(入力フォームのデータを保存したい場合は、下記はない方が良いかも)
   # geocoded_by :address
-  # reverse_geocoded_by :latitude, :longitude
-  # after_validation :geocode
+  reverse_geocoded_by :latitude, :longitude
+  after_validation :geocode
 
   # バリデーション
   validates :address, presence: true


### PR DESCRIPTION
## 概要
- モデルを使用したジオコーディングには「geocoded_by」が、リバースジオコーディング時には「reverse_geocoded_by」の定義が必要らしい。登録データのズレを防ぐだけなら「after_validation」をコメントアウトすれば良かったみたいだ。